### PR TITLE
Add sociology redirect

### DIFF
--- a/rules/rules.json
+++ b/rules/rules.json
@@ -1,4 +1,5 @@
 [
+    "^/sociology/academics/lmas/index.html$ https://artsci.tamu.edu/sociology/lmas/index.html [R=301,NC,L]",
     "^/psychological-brain-sciences/academics/undergraduate/undergraduate.html$ /psychological-brain-sciences/academics/undergraduate/undergraduate-degrees-and-programs.html [R=301,NC,L]",
     "^/philosophy-humanities(.*)$ /philosophy$1 [R=301,NC,L]",
     "^/contact/leadership-team-orig.html$ https://artsci.tamu.edu/contact/leadership-team.html [R=301,L,NC]",


### PR DESCRIPTION
Request by Marcy Heathman: "Dr. Plankey-Videla is asking that we redirect from the old ArtSci Sociology LMAS website here:  https://artsci.tamu.edu/sociology/academics/lmas/index.html to the new link to LMAS which is https://artsci.tamu.edu/sociology/lmas/index.html  (no academics folder). They have QR-coded material that goes to a 404 page now."